### PR TITLE
[gpg.publish] Update keyservers

### DIFF
--- a/bin/gpg.publish
+++ b/bin/gpg.publish
@@ -7,9 +7,17 @@
 
 set -eu
 
-gpg --keyserver pgp.mit.edu --send-key "${KEYID}"
-gpg --keyserver keys.gnupg.net --send-key "${KEYID}"
-gpg --keyserver hkps://keys.openpgp.org --send-key "${KEYID}"
-gpg --keyserver hkps://pgp.ocf.berkeley.edu --send-key "${KEYID}"
-gpg --keyserver hkps://keyserver.ubuntu.com:443 --send-key "${KEYID}"
-gpg --keyserver hkps://hkps.pool.sks-keyservers.net --send-key "${KEYID}"
+# This server is still up but is slow to respond
+# gpg --keyserver pgp.mit.edu --send-key "${KEYID}"
+
+# This will send you an email which you need to decrypt. You can take the body and
+#   pbpaste > ~/tmp/msg.txt
+#   gpg --decrypt < ~/tmp/msg.txt
+gpg --keyserver hkps://keys.mailvelope.com --send-key "${KEYID}"
+
+# https://datatracker.ietf.org/doc/html/draft-gallagher-openpgp-hkp#name-submitting-keys-to-a-keyser
+curl -XPOST --data-urlencode "keytext=$(gpg --export --armor "${KEYID}")" https://keyserver.ubuntu.com/pks/add
+curl -XPOST --data-urlencode "keytext=$(gpg --export --armor "${KEYID}")" https://pgpkeys.eu/pks/add
+
+# This requires a manual verification step; look at the output
+gpg --export "${KEYID}" | curl -T - https://keys.openpgp.org


### PR DESCRIPTION
Since the attacks on SKS servers [1], these servers aren't available anymore:

- `keys.gnupg.net`
- `pool.sks-keyservers.net`
- `pgp.ocf.berkeley.edu` was shut down (see https://github.com/ocf/puppet/issues/816)

`keyserver.ubuntu.com` was switched to use Hockeypuck [2]. Rather than using the HKP protocol, this uses the HTTPS API [3]

This also adds a second Hockeypuck server (`pgpkeys.eu`), which federates with a lot of other servers, and Mailvelope, which runs its own key server software. [4]

For more information, see [5].

[1] https://gist.github.com/rjhansen/67ab921ffb4084c865b3618d6955275f
[2] https://github.com/hockeypuck/hockeypuck
[3] https://datatracker.ietf.org/doc/html/draft-gallagher-openpgp-hkp#name-submitting-keys-to-a-keyser
[4] https://github.com/mailvelope/keyserver
[5] https://nvd.nist.gov/vuln/detail/CVE-2019-13050